### PR TITLE
Added callbacks and renamed sntp.* to avoid naming collisions

### DIFF
--- a/src/ESPPerfectTime.cpp
+++ b/src/ESPPerfectTime.cpp
@@ -10,7 +10,7 @@
 #include <esp32-hal.h>
 #endif // ESP32
 #include "ESPPerfectTime.h"
-#include "sntp.h"
+#include <sntp_pt.h>
 
 #define EPOCH_YEAR                   1970
 #define TIME_2020_01_01_00_00_00_UTC 1577836800

--- a/src/sntp_pt.h
+++ b/src/sntp_pt.h
@@ -33,6 +33,26 @@
 
 namespace pftime_sntp {
 /**
+ * Define sync callback type
+ */
+typedef void (*sync_callback_t)();
+
+/**
+ * Set SNTP sync callback
+ */
+void setsynccallback(sync_callback_t);
+
+/**
+ * Define fail callback type
+ */
+typedef void (*fail_callback_t)(const char*);
+
+/**
+ * Set SNTP fail callback
+ */
+void setfailcallback(fail_callback_t);
+
+/**
  * Initialize this module.
  * Send out request instantly or after SNTP_STARTUP_DELAY(_FUNC).
  */


### PR DESCRIPTION
Hi,

I added callbacks for a succesful sync and a failed sync. I also found that the sntp.* files clashed with system files that had the same name, so I renamed them.